### PR TITLE
Refactor: update project name and set fixed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ OPAL Fetcher for MongoDB
 </h2>
 
 <h4 align="center">
-Made with ❤️ at <a href="https://treedom.net"><img src="https://i.ibb.co/QfYVtP5/Treedom-logo.png" height="24" alt="opal" border="0" /></a>
+Made with ❤️ at <a href="https://treedom.net"><img src="https://i.ibb.co/QfYVtP5/Treedom-logo.png" height="24" alt="treedom" border="0" /></a>
 </h4>
 
 <h6 align="center">
-<a href="https://www.treedom.net/it/organization/treedom/event/treedom-open-source"><img src="https://badges.treedom.net/badge/f/treedom-open-source" alt="opal" border="0" /></a>
+<a href="https://www.treedom.net/it/organization/treedom/event/treedom-open-source"><img src="https://badges.treedom.net/badge/f/treedom-open-source" alt="plant-a-tree" border="0" /></a>
 </h6>
 
 [Check out OPAL main repo here.](https://github.com/permitio/opal)
@@ -36,7 +36,7 @@ The official docker image only contains the built-in fetch providers. You need t
 Your `Dockerfile` should look like this:
 ```
 FROM permitio/opal-client:latest
-RUN pip install --no-cache-dir --user opal-fetcher-mongodb
+RUN pip install --no-cache-dir --user opal-fetcher-mongodb-treedom
 ```
 
 #### 2) Build your custom opal-client container

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ requires = ["setuptools>=61.0", "setuptools_scm[toml]>=7.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = 'opal-fetcher-mongodb'
+name = 'opal-fetcher-mongodb-treedom'
+version = "0.0.1"
 authors = [
     { name="Ionut Andrei Oanca", email="ia.oanca@treedom.net" },
 ]
@@ -30,7 +31,6 @@ dependencies = [
     'tenacity',
     'click',
 ]
-dynamic = ["version"]
 
 [project.urls]
 "Source" = "https://github.com/treedomtrees/opal-fetcher-mongodb"


### PR DESCRIPTION
First demo release available [here](https://test.pypi.org/project/opal-fetcher-mongodb-treedom/).

Test installation with:
```
$ python3 -m venv opal_fetcher_mongodb_env
$ source opal_fetcher_mongodb_env/bin/activate

$ python3 -m pip install --index-url https://test.pypi.org/simple/ --no-deps opal_fetcher_mongodb_treedom
$ python3
>>>from opal_fetcher_mongodb.provider import *
[should fail to import due to missing dependencies]
```