### PR TITLE
Fix: update opal-server docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       # the data sources represents from where the opal clients should get a "complete picture" of the data they need.
       # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
       # Add "fetch_key":"city_id" to get an object with keys of city_id, rather than a list
-      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"mongodb://user:password@mongodb/test_database?authSource=admin","config":{"fetcher":"MongoDBFetchProvider","database":"opal_fetcher_mongodb","collection":"cities_collection","find":{"query":{}}},"topics":["policy_data"],"dst_path":"cities"}]}}
+      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"mongodb://user:password@mongodb/test_database?authSource=admin&directConnection=true","config":{"fetcher":"MongoDBFetchProvider","database":"opal_fetcher_mongodb","collection":"cities_collection","find":{"query":{}}},"topics":["policy_data"],"dst_path":"cities"}]}}
     ports:
       # exposes opal server on the host machine, you can access the server at: http://localhost:7002
       - "7002:7002"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - '5438:5432'
   opal_server:
     # by default we run opal-server from latest official image
-    image: authorizon/opal-server:latest
+    image: permitio/opal-server:latest
     environment:
       # the broadcast backbone uri used by opal server workers (see comments above for: broadcast_channel)
       - OPAL_BROADCAST_URI=postgres://postgres:postgres@broadcast_channel:5432/postgres

--- a/src/opal_fetcher_mongodb/provider.py
+++ b/src/opal_fetcher_mongodb/provider.py
@@ -346,6 +346,8 @@ class MongoDBFetchProvider(BaseFetchProvider):
                 merge = self._event.config.transform.merge
                 if merge is None:
                     merge = False
+            else:
+                merge = False
 
             # handle one single document
             result = None


### PR DESCRIPTION
Should close #6.

Also fixes a missing variable definition when no transform is used.